### PR TITLE
Improved the support for multi threading in the WPF specific parts of the BitmapContext

### DIFF
--- a/Source/WriteableBitmapEx/WriteableBitmapBlitExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapBlitExtensions.cs
@@ -141,14 +141,14 @@ namespace System.Windows.Media.Imaging
             {
                 return;
             }
-#if WPF
-            var isPrgba = source.Format == PixelFormats.Pbgra32 || source.Format == PixelFormats.Prgba64 || source.Format == PixelFormats.Prgba128Float;
-#endif
             var dw = (int)destRect.Width;
             var dh = (int)destRect.Height;
 
             using (var srcContext = source.GetBitmapContext(ReadWriteMode.ReadOnly))
             {
+#if WPF
+                var isPrgba = srcContext.Format == PixelFormats.Pbgra32 || srcContext.Format == PixelFormats.Prgba64 || srcContext.Format == PixelFormats.Prgba128Float;
+#endif
                 using (var destContext = bmp.GetBitmapContext())
                 {
                     var sourceWidth = srcContext.Width;

--- a/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
@@ -592,7 +592,7 @@ namespace System.Windows.Media.Imaging
             {
                 using (var penContext = penBmp.GetBitmapContext(ReadWriteMode.ReadOnly))
                 {
-                    DrawLinePenned(context, bmp.PixelWidth, bmp.PixelHeight, x1, y1, x2, y2, penContext, clipRect);
+                    DrawLinePenned(context, context.Width, context.Height, x1, y1, x2, y2, penContext, clipRect);
                 }
             }
         }
@@ -620,7 +620,7 @@ namespace System.Windows.Media.Imaging
             // Perform cohen-sutherland clipping if either point is out of the viewport
             if (!CohenSutherlandLineClip(clipRect ?? new Rect(0, 0, w, h), ref x1, ref y1, ref x2, ref y2)) return;
 
-            int size = pen.WriteableBitmap.PixelWidth;
+            int size = pen.Width;
             int pw = size;
             var srcRect = new Rect(0, 0, size, size);
 
@@ -970,7 +970,7 @@ namespace System.Windows.Media.Imaging
         {
             using (var context = bmp.GetBitmapContext())
             {
-                DrawLineWu(context, bmp.PixelWidth, bmp.PixelHeight, x1, y1, x2, y2, sa, sr, sg, sb, clipRect);
+                DrawLineWu(context, context.Width, context.Height, x1, y1, x2, y2, sa, sr, sg, sb, clipRect);
             }
         }
 
@@ -1172,7 +1172,7 @@ namespace System.Windows.Media.Imaging
         {
             using (var context = bmp.GetBitmapContext())
             {
-                AAWidthLine(bmp.PixelWidth, bmp.PixelHeight, context, x1, y1, x2, y2, strokeThickness, color, clipRect);
+                AAWidthLine(context.Width, context.Height, context, x1, y1, x2, y2, strokeThickness, color, clipRect);
             }
         }
 
@@ -1207,7 +1207,7 @@ namespace System.Windows.Media.Imaging
             var col = ConvertColor(color);
             using (var context = bmp.GetBitmapContext())
             {
-                AAWidthLine(bmp.PixelWidth, bmp.PixelHeight, context, x1, y1, x2, y2, strokeThickness, col, clipRect);
+                AAWidthLine(context.Width, context.Height, context, x1, y1, x2, y2, strokeThickness, col, clipRect);
             }
         }
 

--- a/Source/WriteableBitmapEx/WriteableBitmapTransformationExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapTransformationExtensions.cs
@@ -379,7 +379,7 @@ namespace System.Windows.Media.Imaging
                 }
                 else
                 {
-                    result = bmp.Clone();
+                    result = WriteableBitmapExtensions.Clone(bmp);
                 }
                 return result;
             }


### PR DESCRIPTION
* When the first instance is being created, it makes a copy of all the important parameters from the WriteableBitmap for all other instances to use
* Fixed a few whitespace errors
* Changed a few properties to use the already captured instance variables instead of proxying towards the WriteableBitmap