### PR TITLE
[#68] Fix Overflow in DrawLine.

### DIFF
--- a/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
@@ -550,7 +550,7 @@ namespace System.Windows.Media.Imaging
                     y2 = pixelHeight - 1;
                 }
 
-                int index = x1s;
+                long index = x1s;
                 int indexBaseValue = y1 * pixelWidth;
 
                 // Walk the line!


### PR DESCRIPTION
- Changed index variable type in DrawLine to long to fix an overflow causing an AccessViolation exception.