### PR TITLE
DrawLineAa transparency

### DIFF
--- a/Source/WriteableBitmapEx/WriteableBitmapAntialiasingExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapAntialiasingExtensions.cs
@@ -57,6 +57,20 @@ namespace System.Windows.Media.Imaging
                 Swap(ref y1, ref y2);
             }
 
+
+            byte rs, gs, bs, @as;//input color components
+
+            {
+                @as = (byte)((color & 0xff000000) >> 24);
+                @rs = (byte)((color & 0x00ff0000) >> 16);
+                @gs = (byte)((color & 0x0000ff00) >> 8);
+                @bs = (byte)((color & 0x000000ff) >> 0);
+            }
+
+            byte rd, gd, bd, ad;//ARGB components of each pixel
+            Int32 d;//combined ARGB component of each pixel
+
+
             if (x1 == x2)
             {
                 x1 -= (int)lineWidth / 2;
@@ -84,29 +98,16 @@ namespace System.Windows.Media.Imaging
                 {
                     for (var y = (int)y1; y <= y2; y++)
                     {
-                        var a = (byte)((color & 0xff000000) >> 24);
-                        var r = (byte)((color & 0x00ff0000) >> 16);
-                        var g = (byte)((color & 0x0000ff00) >> 8);
-                        var b = (byte)((color & 0x000000ff) >> 0);
-
-                        byte rs, gs, bs;
-                        byte rd, gd, bd;
-
-                        int d;
-
-                        rs = r;
-                        gs = g;
-                        bs = b;
-
                         d = buffer[y * width + x];
 
+                        ad = (byte)((d & 0xff000000) >> 24);
                         rd = (byte)((d & 0x00ff0000) >> 16);
                         gd = (byte)((d & 0x0000ff00) >> 8);
                         bd = (byte)((d & 0x000000ff) >> 0);
 
-                        rd = (byte)((rs * a + rd * (0xff - a)) >> 8);
-                        gd = (byte)((gs * a + gd * (0xff - a)) >> 8);
-                        bd = (byte)((bs * a + bd * (0xff - a)) >> 8);
+                        rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
+                        gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
+                        bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
 
                         buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
                     }
@@ -114,6 +115,7 @@ namespace System.Windows.Media.Imaging
 
                 return;
             }
+
             if (y1 == y2)
             {
                 if (x1 > x2) Swap(ref x1, ref x2);
@@ -136,29 +138,16 @@ namespace System.Windows.Media.Imaging
                 {
                     for (var y = (int)y1; y <= y2; y++)
                     {
-                        var a = (byte)((color & 0xff000000) >> 24);
-                        var r = (byte)((color & 0x00ff0000) >> 16);
-                        var g = (byte)((color & 0x0000ff00) >> 8);
-                        var b = (byte)((color & 0x000000ff) >> 0);
-
-                        Byte rs, gs, bs;
-                        Byte rd, gd, bd;
-
-                        Int32 d;
-
-                        rs = r;
-                        gs = g;
-                        bs = b;
-
                         d = buffer[y * width + x];
-
+                        
+                        ad = (byte)((d & 0xff000000) >> 24);
                         rd = (byte)((d & 0x00ff0000) >> 16);
                         gd = (byte)((d & 0x0000ff00) >> 8);
                         bd = (byte)((d & 0x000000ff) >> 0);
 
-                        rd = (byte)((rs * a + rd * (0xff - a)) >> 8);
-                        gd = (byte)((gs * a + gd * (0xff - a)) >> 8);
-                        bd = (byte)((bs * a + bd * (0xff - a)) >> 8);
+                        rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
+                        gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
+                        bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
 
                         buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
                     }
@@ -282,29 +271,16 @@ namespace System.Windows.Media.Imaging
 
                 for (int x = leftEdgeX[y]; x <= rightEdgeX[y]; x++)
                 {
-                    var a = (byte)((color & 0xff000000) >> 24);
-                    var r = (byte)((color & 0x00ff0000) >> 16);
-                    var g = (byte)((color & 0x0000ff00) >> 8);
-                    var b = (byte)((color & 0x000000ff) >> 0);
-
-                    Byte rs, gs, bs;
-                    Byte rd, gd, bd;
-
-                    Int32 d;
-
-                    rs = r;
-                    gs = g;
-                    bs = b;
-
                     d = buffer[y * width + x];
 
+                    ad = (byte)((d & 0xff000000) >> 24);
                     rd = (byte)((d & 0x00ff0000) >> 16);
                     gd = (byte)((d & 0x0000ff00) >> 8);
                     bd = (byte)((d & 0x000000ff) >> 0);
 
-                    rd = (byte)((rs * a + rd * (0xff - a)) >> 8);
-                    gd = (byte)((gs * a + gd * (0xff - a)) >> 8);
-                    bd = (byte)((bs * a + bd * (0xff - a)) >> 8);
+                    rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
+                    gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
+                    bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
 
                     buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
                 }

--- a/Source/WriteableBitmapEx/WriteableBitmapAntialiasingExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapAntialiasingExtensions.cs
@@ -68,7 +68,7 @@ namespace System.Windows.Media.Imaging
             }
 
             byte rd, gd, bd, ad;//ARGB components of each pixel
-            Int32 d;//combined ARGB component of each pixel
+            Int32 d;//combined ARGB component of each pixel, the destination pixel
 
 
             if (x1 == x2)
@@ -105,6 +105,7 @@ namespace System.Windows.Media.Imaging
                         gd = (byte)((d & 0x0000ff00) >> 8);
                         bd = (byte)((d & 0x000000ff) >> 0);
 
+                        ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
                         rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
                         gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
                         bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
@@ -145,6 +146,7 @@ namespace System.Windows.Media.Imaging
                         gd = (byte)((d & 0x0000ff00) >> 8);
                         bd = (byte)((d & 0x000000ff) >> 0);
 
+                        ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
                         rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
                         gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
                         bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
@@ -241,7 +243,7 @@ namespace System.Windows.Media.Imaging
                 rightEdgeX[y] = 1 << 16 - 1;
             }
 
-
+            /**/
             AALineQ1(width, height, context, ix1, iy1, ix2, iy2, color, sy > 0, false);
             AALineQ1(width, height, context, ix3, iy3, ix4, iy4, color, sy < 0, true);
 
@@ -250,6 +252,7 @@ namespace System.Windows.Media.Imaging
                 AALineQ1(width, height, context, ix1, iy1, ix3, iy3, color, true, sy > 0);
                 AALineQ1(width, height, context, ix2, iy2, ix4, iy4, color, false, sy < 0);
             }
+            /**/
 
             if (x1 < x2)
             {
@@ -278,6 +281,7 @@ namespace System.Windows.Media.Imaging
                     gd = (byte)((d & 0x0000ff00) >> 8);
                     bd = (byte)((d & 0x000000ff) >> 0);
 
+                    ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
                     rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
                     gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
                     bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);

--- a/Source/WriteableBitmapEx/WriteableBitmapAntialiasingExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapAntialiasingExtensions.cs
@@ -105,12 +105,22 @@ namespace System.Windows.Media.Imaging
                         gd = (byte)((d & 0x0000ff00) >> 8);
                         bd = (byte)((d & 0x000000ff) >> 0);
 
-                        ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
-                        rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
-                        gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
-                        bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
+                        {
 
-                        buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+#if Flag1
+                            ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
+                            rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
+                            gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
+                            bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
+
+                            d = (ad << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+#else
+
+                            d = AlphaBlendArgbPixels(@as, rs, gs, bs, ad, rd, gd, bd);
+#endif
+                        }
+
+                        buffer[y * width + x] = d;// 
                     }
                 }
 
@@ -146,12 +156,21 @@ namespace System.Windows.Media.Imaging
                         gd = (byte)((d & 0x0000ff00) >> 8);
                         bd = (byte)((d & 0x000000ff) >> 0);
 
-                        ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
-                        rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
-                        gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
-                        bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
+                        {
+#if Flag1
+                            ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
+                            rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
+                            gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
+                            bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
 
-                        buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+                            d = (ad << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+#else
+
+                            d = AlphaBlendArgbPixels(@as, rs, gs, bs, ad, rd, gd, bd);
+#endif
+                        }
+
+                        buffer[y * width + x] = d;// (ad << 24) | (rd << 16) | (gd << 8) | (bd << 0);
                     }
                 }
 
@@ -281,12 +300,21 @@ namespace System.Windows.Media.Imaging
                     gd = (byte)((d & 0x0000ff00) >> 8);
                     bd = (byte)((d & 0x000000ff) >> 0);
 
-                    ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
-                    rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
-                    gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
-                    bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
+                    {
+#if Flag1
+                            ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
+                            rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
+                            gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
+                            bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
 
-                    buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+                            d = (ad << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+#else
+
+                        d = AlphaBlendArgbPixels(@as, rs, gs, bs, ad, rd, gd, bd);
+#endif
+                    }
+
+                    buffer[y * width + x] = d;// (ad << 24) | (rd << 16) | (gd << 8) | (bd << 0);
                 }
             }
         }
@@ -330,17 +358,20 @@ namespace System.Windows.Media.Imaging
 
             UInt16 e = 0;
 
-            var a = (byte)((color & 0xff000000) >> 24);
-            var r = (byte)((color & 0x00ff0000) >> 16);
-            var g = (byte)((color & 0x0000ff00) >> 8);
-            var b = (byte)((color & 0x000000ff) >> 0);
+            Byte rs, gs, bs, @as;
 
-            Byte rs, gs, bs;
-            Byte rd, gd, bd;
+            {
+                @as = (byte)((color & 0xff000000) >> 24);
+                rs = (byte)((color & 0x00ff0000) >> 16);
+                gs = (byte)((color & 0x0000ff00) >> 8);
+                bs = (byte)((color & 0x000000ff) >> 0);
+            }
+
+            Byte rd, gd, bd, ad;
 
             Int32 d;
 
-            Byte ta = a;
+            Byte ta = @as;
 
             e = 0;
 
@@ -367,25 +398,30 @@ namespace System.Windows.Media.Imaging
 
                     //
 
-                    ta = (byte)((a * (UInt16)(((((UInt16)(e >> 8))) ^ off))) >> 8);
-
-                    rs = r;
-                    gs = g;
-                    bs = b;
+                    ta = (byte)((@as * (UInt16)(((((UInt16)(e >> 8))) ^ off))) >> 8);//target alpha
 
                     d = buffer[y * width + x];
 
+                    ad = (byte)((d & 0xff000000) >> 24);
                     rd = (byte)((d & 0x00ff0000) >> 16);
                     gd = (byte)((d & 0x0000ff00) >> 8);
                     bd = (byte)((d & 0x000000ff) >> 0);
 
-                    rd = (byte)((rs * ta + rd * (0xff - ta)) >> 8);
-                    gd = (byte)((gs * ta + gd * (0xff - ta)) >> 8);
-                    bd = (byte)((bs * ta + bd * (0xff - ta)) >> 8);
+                    {
+#if Flag1
+                            ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
+                            rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
+                            gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
+                            bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
 
-                    buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+                            d = (ad << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+#else
 
-                    //
+                        d = AlphaBlendArgbPixels(@as, rs, gs, bs, ad, rd, gd, bd);
+#endif
+                    }
+
+                    buffer[y * width + x] = d;
                 }
             }
             else
@@ -409,23 +445,30 @@ namespace System.Windows.Media.Imaging
 
                     //
 
-                    ta = (byte)((a * (UInt16)(((((UInt16)(e >> 8))) ^ off))) >> 8);
-
-                    rs = r;
-                    gs = g;
-                    bs = b;
+                    ta = (byte)((@as * (UInt16)(((((UInt16)(e >> 8))) ^ off))) >> 8);
 
                     d = buffer[y * width + x];
 
+                    ad = (byte)((d & 0xff000000) >> 24);
                     rd = (byte)((d & 0x00ff0000) >> 16);
                     gd = (byte)((d & 0x0000ff00) >> 8);
                     bd = (byte)((d & 0x000000ff) >> 0);
 
-                    rd = (byte)((rs * ta + rd * (0xff - ta)) >> 8);
-                    gd = (byte)((gs * ta + gd * (0xff - ta)) >> 8);
-                    bd = (byte)((bs * ta + bd * (0xff - ta)) >> 8);
+                    {
+#if Flag1
+                            ad = (byte)((@as * @as + ad * (0xff - @as)) >> 8);
+                            rd = (byte)((rs * @as + rd * (0xff - @as)) >> 8);
+                            gd = (byte)((gs * @as + gd * (0xff - @as)) >> 8);
+                            bd = (byte)((bs * @as + bd * (0xff - @as)) >> 8);
 
-                    buffer[y * width + x] = (0xff << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+                            d = (ad << 24) | (rd << 16) | (gd << 8) | (bd << 0);
+#else
+
+                        d = AlphaBlendArgbPixels(@as, rs, gs, bs, ad, rd, gd, bd);
+#endif
+                    }
+
+                    buffer[y * width + x] = d;
 
                     if (leftEdge) leftEdgeX[y] = x + 1;
                     else rightEdgeX[y] = x - 1;

--- a/Source/WriteableBitmapEx/WriteableBitmapBaseExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapBaseExtensions.cs
@@ -71,6 +71,16 @@ namespace System.Windows.Media.Imaging
             return col;
         }
 
+        // same as ConvertColor() but takes care of the transparency
+        public static int ConvertColorT(Color color)
+        {
+            int col = 0;
+
+            col = color.A << 24 | color.R << 16 | color.G << 8 | color.B;
+
+            return col;
+        }
+
         /// <summary>
         /// Fills the whole WriteableBitmap with a color.
         /// </summary>

--- a/Source/WriteableBitmapEx/WriteableBitmapBaseExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapBaseExtensions.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Runtime.CompilerServices;
 
 #if NETFX_CORE
 namespace Windows.UI.Xaml.Media.Imaging
@@ -79,6 +80,32 @@ namespace System.Windows.Media.Imaging
             col = color.A << 24 | color.R << 16 | color.G << 8 | color.B;
 
             return col;
+        }
+
+
+        /// <summary>
+        /// Belnds two pixels regarding their alpha
+        /// </summary>
+        /// <returns>blended</returns>
+        [MethodImpl(256)]
+        public static int AlphaBlendArgbPixels(byte a1, byte r1, byte g1, byte b1, byte a2, byte r2, byte g2, byte b2)
+        {
+            //inlined
+            //bends two pixel and return ARGB result as int
+            //[MethodImpl(256)] equals to MethodImplOptions.AggressiveInlining, add support for net40, tested on net40 working
+            //https://stackoverflow.com/a/8746128
+            //https://stackoverflow.com/a/43060488
+            //s:1
+            //d:2
+
+            var a1not = (byte)(0xff - a1);
+
+            var ad = (byte)((a1 * a1 + a2 * a1not) >> 8);
+            var rd = (byte)((r1 * a1 + r2 * a1not) >> 8);
+            var gd = (byte)((g1 * a1 + g2 * a1not) >> 8);
+            var bd = (byte)((b1 * a1 + b2 * a1not) >> 8);
+
+            return ad << 24 | rd << 16 | gd << 8 | bd;
         }
 
         /// <summary>
@@ -144,7 +171,7 @@ namespace System.Windows.Media.Imaging
             }
         }
 
-        #endregion
+#endregion
 
         #region ForEach
 
@@ -485,6 +512,6 @@ namespace System.Windows.Media.Imaging
 
         #endregion
 
-        #endregion
+#endregion
     }
 }

--- a/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
+++ b/Source/WriteableBitmapEx/WriteableBitmapLineExtensions.cs
@@ -1188,7 +1188,7 @@ namespace System.Windows.Media.Imaging
         /// </summary>
         public static void DrawLineAa(BitmapContext context, int pixelWidth, int pixelHeight, int x1, int y1, int x2, int y2, Color color, int strokeThickness, Rect? clipRect = null)
         {
-            var col = ConvertColor(color);
+            var col = ConvertColorT(color);
             AAWidthLine(pixelWidth, pixelHeight, context, x1, y1, x2, y2, strokeThickness, col, clipRect);
         }
 
@@ -1204,7 +1204,7 @@ namespace System.Windows.Media.Imaging
         /// </summary>
         public static void DrawLineAa(this WriteableBitmap bmp, int x1, int y1, int x2, int y2, Color color, int strokeThickness, Rect? clipRect = null)
         {
-            var col = ConvertColor(color);
+            var col = ConvertColorT(color);
             using (var context = bmp.GetBitmapContext())
             {
                 AAWidthLine(context.Width, context.Height, context, x1, y1, x2, y2, strokeThickness, col, clipRect);
@@ -1223,7 +1223,7 @@ namespace System.Windows.Media.Imaging
         /// </summary> 
         public static void DrawLineAa(this WriteableBitmap bmp, int x1, int y1, int x2, int y2, Color color, Rect? clipRect = null)
         {
-            var col = ConvertColor(color);
+            var col = ConvertColorT(color);
             bmp.DrawLineAa(x1, y1, x2, y2, col, clipRect);
         }
 


### PR DESCRIPTION
There where two major issues:
- Drawing a semi transparent line on a semi transparent background
- Drawing a non transparent line (with anti aliased edge) on a (semi) transparent background.

In both cases, transparency where lost on changed pixels.

Before:
<img width="499" alt="1" src="https://github.com/user-attachments/assets/e5bb224a-0408-4917-b674-8a2bc872e8f1" />

After:
<img width="490" alt="3" src="https://github.com/user-attachments/assets/71006ba1-227d-4a1f-8d01-c961ca869d10" />

Having ``AlphaBlendArgbPixels`` method with `MethodImplOptions.AggressiveInlining` do not have any negative effect on performance (tested).